### PR TITLE
Eli locateable

### DIFF
--- a/src/edu/cpp/cs/cs141/GECLYfinalproj/Locatable.java
+++ b/src/edu/cpp/cs/cs141/GECLYfinalproj/Locatable.java
@@ -16,5 +16,35 @@ package edu.cpp.cs.cs141.GECLYfinalproj;
  * Yan Huang (Lilli)
  *
  */
+
+
+/**
+ * Locatable is an interface designed for objects that appear on the main game grid. It contains methods for retrieving 
+ * 
+ * @author eli
+ *
+ */
 public interface Locatable {
+	
+	/**
+	 * Returns the ASCII character used to display this object when the game is played in the console. Whether the tile is visible to the player can be specified.
+	 * 
+	 * Examples: 'A','r','*',' '.
+	 * 
+	 * @param visible whether the player can see the grid square that contains this object
+	 * @return the character used to display this object, or null if this object should not be displayed
+	 */
+	public char getASCIIDisplayCharacter(boolean visible);
+	
+	/**
+	 * Returns the Unicode character used to display this object when the game is played in the console. Whether the tile is visible to the player can be specified.
+	 * 
+	 * Examples: '♕','♿','⚑','♦'.
+	 * 
+	 * @param visible whether the player can see the grid square that contains this object
+	 * @return the character used to display this object, or null if this object should not be displayed
+	 */
+	public char getUnicodeDisplayCharacter(boolean visible);
+	
+	
 }

--- a/src/edu/cpp/cs/cs141/GECLYfinalproj/Locatable.java
+++ b/src/edu/cpp/cs/cs141/GECLYfinalproj/Locatable.java
@@ -46,5 +46,9 @@ public interface Locatable {
 	 */
 	public char getUnicodeDisplayCharacter(boolean visible);
 	
+	//TODO: Add methods for retrieving images for these items
+	
+	//Question: Do we want methods for getting the location of this object, the distance to another object, and the grid that this object is currently on?
+	
 	
 }


### PR DESCRIPTION
Adds a basic implementation of the Locatable interface, allowing implementors to give their display characters (in both ASCII and Unicode mode). Because it is an interface, the skeleton code and the implementation are the same thing. 